### PR TITLE
SLING-11119 - Optimise the service retrieval for bundled scripts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,12 @@
             <artifactId>osgi.core</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.http.whiteboard</artifactId>
+            <version>1.1.0</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- for serializing to JSON, must be after osgi.core to make Maven use the correct osgi.core version -->
         <dependency>
             <groupId>org.apache.felix</groupId>
@@ -244,15 +250,15 @@
 
         <dependency>
             <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.testing.osgi-mock</artifactId>
-            <version>2.3.6</version>
+            <artifactId>org.apache.sling.testing.osgi-mock.junit4</artifactId>
+            <version>3.2.2</version>
             <scope>test</scope>
         </dependency>
         
         <dependency>
             <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.testing.sling-mock</artifactId>
-            <version>2.2.14</version>
+            <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
+            <version>3.2.2</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/src/main/java/org/apache/sling/scripting/core/impl/InternalScriptHelper.java
+++ b/src/main/java/org/apache/sling/scripting/core/impl/InternalScriptHelper.java
@@ -20,6 +20,7 @@ package org.apache.sling.scripting.core.impl;
 
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.scripting.InvalidServiceFilterSyntaxException;
 import org.apache.sling.api.scripting.SlingScript;
 import org.apache.sling.scripting.core.ScriptHelper;
 import org.osgi.framework.BundleContext;
@@ -52,5 +53,11 @@ public class InternalScriptHelper extends ScriptHelper {
      */
     public <ServiceType> ServiceType getService(Class<ServiceType> type) {
         return this.serviceCache.getService(type);
+    }
+
+    @Override
+    public <ServiceType> ServiceType[] getServices(Class<ServiceType> serviceType, String filter)
+            throws InvalidServiceFilterSyntaxException {
+        return this.serviceCache.getServices(serviceType, filter);
     }
 }

--- a/src/main/java/org/apache/sling/scripting/core/impl/ServiceCache.java
+++ b/src/main/java/org/apache/sling/scripting/core/impl/ServiceCache.java
@@ -22,12 +22,12 @@ import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.SortedSet;
-import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
+import java.util.concurrent.ConcurrentSkipListSet;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -147,7 +147,7 @@ public class ServiceCache implements ServiceListener {
         String key = type.getName();
         SortedSet<Reference> references = cache.get(key);
         if (references == null) {
-            references = Collections.synchronizedSortedSet(new TreeSet<>((o1, o2) -> -1 * o1.compareTo(o2)));
+            references = new ConcurrentSkipListSet<>(Comparator.reverseOrder());
             try {
                 Collection<ServiceReference<ServiceType>> serviceReferences = this.bundleContext.getServiceReferences(type, null);
                 if (!serviceReferences.isEmpty()) {
@@ -160,8 +160,7 @@ public class ServiceCache implements ServiceListener {
                     synchronized (this) {
                         SortedSet<Reference> existing = this.cache.get(key);
                         if (existing != null) {
-                            existing.addAll(
-                                    references.stream().filter(reference -> !existing.contains(reference)).collect(Collectors.toList()));
+                            existing.addAll(references);
                             references = existing;
                         } else {
                             this.cache.put(key, references);

--- a/src/main/java/org/apache/sling/scripting/core/impl/bundled/AbstractBundledRenderUnit.java
+++ b/src/main/java/org/apache/sling/scripting/core/impl/bundled/AbstractBundledRenderUnit.java
@@ -33,6 +33,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.wiring.BundleWiring;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,7 +105,8 @@ abstract class AbstractBundledRenderUnit implements ExecutableUnit {
     @SuppressWarnings("unchecked")
     public <T> T getService(@NotNull String className) {
         try {
-            return (T) serviceCache.getService(Class.forName(className));
+            ClassLoader bundleClassloader = getBundle().adapt(BundleWiring.class).getClassLoader();
+            return (T) serviceCache.getService(bundleClassloader.loadClass(className));
         } catch (ClassNotFoundException e) {
             LOG.error("Unable to retrieve a service of type " + className + " for bundled script " + path, e);
         }
@@ -116,7 +118,8 @@ abstract class AbstractBundledRenderUnit implements ExecutableUnit {
     @SuppressWarnings("unchecked")
     public <T> T[] getServices(@NotNull String className, @Nullable String filter) {
         try {
-            return (T[]) serviceCache.getServices(Class.forName(className), filter);
+            ClassLoader bundleClassloader = getBundle().adapt(BundleWiring.class).getClassLoader();
+            return (T[]) serviceCache.getServices(bundleClassloader.loadClass(className), filter);
         } catch (ClassNotFoundException e) {
             LOG.error("Unable to retrieve a service of type " + className + " for bundled script " + path, e);
         }

--- a/src/main/java/org/apache/sling/scripting/core/impl/bundled/AbstractBundledRenderUnit.java
+++ b/src/main/java/org/apache/sling/scripting/core/impl/bundled/AbstractBundledRenderUnit.java
@@ -19,13 +19,6 @@
 package org.apache.sling.scripting.core.impl.bundled;
 
 import java.io.IOException;
-import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import javax.script.ScriptException;
@@ -34,12 +27,12 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.scripting.core.impl.ServiceCache;
 import org.apache.sling.scripting.spi.bundle.TypeProvider;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,12 +47,11 @@ abstract class AbstractBundledRenderUnit implements ExecutableUnit {
     private final String scriptEngineName;
     private final String scriptExtension;
     private final ScriptContextProvider scriptContextProvider;
-    private List<ServiceReference<?>> references;
-    private Map<String, Object> services;
-
+    private final ServiceCache serviceCache;
 
     AbstractBundledRenderUnit(@NotNull Set<TypeProvider> providers, @NotNull BundleContext context, @NotNull Bundle bundle, @NotNull String path,
-                              @NotNull String scriptEngineName, @NotNull String scriptExtension, @NotNull ScriptContextProvider scriptContextProvider) {
+                              @NotNull String scriptEngineName, @NotNull String scriptExtension,
+                              @NotNull ScriptContextProvider scriptContextProvider, @NotNull ServiceCache serviceCache) {
         this.providers = providers;
         this.bundle = bundle;
         this.path = path;
@@ -67,6 +59,7 @@ abstract class AbstractBundledRenderUnit implements ExecutableUnit {
         this.scriptExtension = scriptExtension;
         this.scriptContextProvider = scriptContextProvider;
         this.bundleContext = context;
+        this.serviceCache = serviceCache;
     }
 
     @Override
@@ -102,81 +95,33 @@ abstract class AbstractBundledRenderUnit implements ExecutableUnit {
     }
 
     @Override
+    public @NotNull ServiceCache getServiceCache() {
+        return serviceCache;
+    }
+
+    @Override
     @Nullable
     @SuppressWarnings("unchecked")
     public <T> T getService(@NotNull String className) {
-        LOG.debug("Attempting to load class {} as an OSGi service.", className);
-        T result = (this.services == null ? null : (T) this.services.get(className));
-        if (result == null) {
-            final ServiceReference<?> ref = this.bundleContext.getServiceReference(className);
-            if (ref != null) {
-                result = (T) this.bundleContext.getService(ref);
-                if (result != null) {
-                    if (this.services == null) {
-                        this.services = new HashMap<>();
-                    }
-                    if (this.references == null) {
-                        this.references = new ArrayList<>();
-                    }
-                    this.references.add(ref);
-                    this.services.put(className, result);
-                    return result;
-                }
-            }
+        try {
+            return (T) serviceCache.getService(Class.forName(className));
+        } catch (ClassNotFoundException e) {
+            LOG.error("Unable to retrieve a service of type " + className + " for bundled script " + path, e);
         }
-        return result;
+        return null;
     }
 
     @Override
     @Nullable
     @SuppressWarnings("unchecked")
     public <T> T[] getServices(@NotNull String className, @Nullable String filter) {
-        T[] result = null;
         try {
-            final ServiceReference<?>[] refs = this.bundleContext.getServiceReferences(className, filter);
-
-            if (refs != null) {
-                // sort by service ranking (lowest first) (see ServiceReference#compareTo(Object))
-                List<ServiceReference<?>> localReferences = Arrays.asList(refs);
-                Collections.sort(localReferences);
-                // get the highest ranking first
-                Collections.reverse(localReferences);
-
-                final List<T> objects = new ArrayList<>();
-                for (ServiceReference<?> reference : localReferences) {
-                    final T service = (T) this.bundleContext.getService(reference);
-                    if (service != null) {
-                        if (this.references == null) {
-                            this.references = new ArrayList<>();
-                        }
-                        this.references.add(reference);
-                        objects.add(service);
-                    }
-                }
-                if (!objects.isEmpty()) {
-                    T[] srv = (T[]) Array.newInstance(bundle.loadClass(className), objects.size());
-                    result = objects.toArray(srv);
-                }
-            }
-        } catch (Exception e) {
-            LOG.error(String.format("Unable to retrieve the services of type %s.", className), e);
+            return (T[]) serviceCache.getServices(Class.forName(className), filter);
+        } catch (ClassNotFoundException e) {
+            LOG.error("Unable to retrieve a service of type " + className + " for bundled script " + path, e);
         }
-        return result;
+        return null;
     }
-
-    @Override
-    public void releaseDependencies() {
-        if (references != null) {
-            for (ServiceReference<?> reference : this.references) {
-                bundleContext.ungetService(reference);
-            }
-            references.clear();
-        }
-        if (services != null) {
-            services.clear();
-        }
-    }
-
 
     @Override
     public void eval(@NotNull HttpServletRequest request, @NotNull HttpServletResponse response) throws ScriptException {

--- a/src/main/java/org/apache/sling/scripting/core/impl/bundled/ExecutableUnit.java
+++ b/src/main/java/org/apache/sling/scripting/core/impl/bundled/ExecutableUnit.java
@@ -22,16 +22,11 @@ import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 
+import org.apache.sling.scripting.core.impl.ServiceCache;
 import org.apache.sling.scripting.spi.bundle.BundledRenderUnit;
 import org.jetbrains.annotations.NotNull;
 
-interface ExecutableUnit extends BundledRenderUnit
-{
-
-    /**
-     * Releases all acquired dependencies which were retrieved through {@link #getService(String)} or {@link #getServices(String, String)}.
-     */
-    void releaseDependencies();
+interface ExecutableUnit extends BundledRenderUnit {
 
     /**
      * Returns the short name of the {@link ScriptEngine} with which {@code this ExecutableUnit} can be evaluated.
@@ -58,4 +53,13 @@ interface ExecutableUnit extends BundledRenderUnit
      * @throws ScriptException if the execution leads to an error
      */
     void eval(@NotNull ScriptEngine scriptEngine, @NotNull ScriptContext context) throws ScriptException;
+
+    /**
+     * Returns the {@link ServiceCache} that's used for retrieving OSGi dependencies at run-time for this executable unit. The {@link
+     * ServiceCache} is based on the {@link org.osgi.framework.BundleContext} provided by {@link #getBundleContext()}.
+     *
+     * @return the service cache
+     */
+    @NotNull
+    ServiceCache getServiceCache();
 }

--- a/src/main/java/org/apache/sling/scripting/core/impl/bundled/PrecompiledScript.java
+++ b/src/main/java/org/apache/sling/scripting/core/impl/bundled/PrecompiledScript.java
@@ -26,6 +26,7 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.scripting.core.impl.ServiceCache;
 import org.apache.sling.scripting.spi.bundle.TypeProvider;
 import org.jetbrains.annotations.NotNull;
 import org.osgi.framework.Bundle;
@@ -38,8 +39,9 @@ class PrecompiledScript extends AbstractBundledRenderUnit {
     private volatile Object instance;
 
     PrecompiledScript(@NotNull Set<TypeProvider> providers, @NotNull BundleContext context, @NotNull Bundle bundle, @NotNull String path, @NotNull Class<?> clazz,
-                      @NotNull String scriptEngineName, @NotNull String scriptExtension, @NotNull ScriptContextProvider scriptContextProvider) {
-        super(providers, context, bundle, path, scriptEngineName, scriptExtension, scriptContextProvider);
+                      @NotNull String scriptEngineName, @NotNull String scriptExtension,
+                      @NotNull ScriptContextProvider scriptContextProvider, @NotNull ServiceCache serviceCache) {
+        super(providers, context, bundle, path, scriptEngineName, scriptExtension, scriptContextProvider, serviceCache);
         this.clazz = clazz;
     }
 

--- a/src/main/java/org/apache/sling/scripting/core/impl/bundled/Script.java
+++ b/src/main/java/org/apache/sling/scripting/core/impl/bundled/Script.java
@@ -35,6 +35,7 @@ import javax.script.ScriptException;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.sling.scripting.core.ScriptNameAwareReader;
+import org.apache.sling.scripting.core.impl.ServiceCache;
 import org.apache.sling.scripting.spi.bundle.TypeProvider;
 import org.jetbrains.annotations.NotNull;
 import org.osgi.framework.Bundle;
@@ -50,8 +51,9 @@ class Script extends AbstractBundledRenderUnit {
 
 
     Script(@NotNull Set<TypeProvider> providers, @NotNull BundleContext context, @NotNull Bundle bundle, @NotNull String path, @NotNull URL url,
-           @NotNull String scriptEngineName, @NotNull String scriptExtension, @NotNull ScriptContextProvider scriptContextProvider) {
-        super(providers, context, bundle, path, scriptEngineName, scriptExtension, scriptContextProvider);
+           @NotNull String scriptEngineName, @NotNull String scriptExtension, @NotNull ScriptContextProvider scriptContextProvider,
+           @NotNull ServiceCache serviceCache) {
+        super(providers, context, bundle, path, scriptEngineName, scriptExtension, scriptContextProvider, serviceCache);
         this.url = url;
     }
 

--- a/src/test/java/org/apache/sling/scripting/core/impl/ServiceCacheTest.java
+++ b/src/test/java/org/apache/sling/scripting/core/impl/ServiceCacheTest.java
@@ -1,0 +1,105 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Licensed to the Apache Software Foundation (ASF) under one
+ ~ or more contributor license agreements.  See the NOTICE file
+ ~ distributed with this work for additional information
+ ~ regarding copyright ownership.  The ASF licenses this file
+ ~ to you under the Apache License, Version 2.0 (the
+ ~ "License"); you may not use this file except in compliance
+ ~ with the License.  You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package org.apache.sling.scripting.core.impl;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ServiceCacheTest {
+
+    @Rule
+    public OsgiContext osgiContext = new OsgiContext();
+
+    private BundleContext bundleContext;
+    private ServiceCache serviceCache;
+
+    @Before
+    public void before() {
+        bundleContext = osgiContext.bundleContext();
+        serviceCache = new ServiceCache(bundleContext);
+    }
+
+    @Test
+    public void testGetService() {
+        TestService ts1 = new TestService("ts1");
+        bundleContext.registerService(TestService.class, ts1, new Hashtable<>());
+        assertEquals("The ServiceCache should have returned the same service that was registered first.", ts1,
+                serviceCache.getService(TestService.class));
+        assertArrayEquals(new TestService[] {ts1}, serviceCache.getServices(TestService.class, null));
+
+        TestService ts2 = new TestService("ts2");
+        bundleContext.registerService(TestService.class, ts2, new Hashtable<>());
+        assertEquals("The ServiceCache should have returned the first service that was registered.", ts1,
+                serviceCache.getService(TestService.class));
+        assertArrayEquals(new TestService[] {ts1, ts2}, serviceCache.getServices(TestService.class, null));
+
+        TestService ts3 = new TestService("ts3");
+        Dictionary<String, Object> properties = new Hashtable<>();
+        properties.put(Constants.SERVICE_RANKING, Integer.MAX_VALUE);
+        bundleContext.registerService(TestService.class, ts3, properties);
+        assertEquals("The ServiceCache should have now returned the service with the highest ranking.", ts3,
+                serviceCache.getService(TestService.class));
+        assertArrayEquals(new TestService[] {ts3, ts1, ts2}, serviceCache.getServices(TestService.class, null));
+    }
+
+    @Test
+    public void testGetServices() {
+        TestService ts1 = new TestService("ts1");
+        bundleContext.registerService(TestService.class, ts1, new Hashtable<>());
+        assertArrayEquals(new TestService[] {ts1}, serviceCache.getServices(TestService.class, null));
+        assertEquals("The ServiceCache should have returned the same service that was registered first.", ts1,
+                serviceCache.getService(TestService.class));
+
+        TestService ts2 = new TestService("ts2");
+        bundleContext.registerService(TestService.class, ts2, new Hashtable<>());
+        assertArrayEquals(new TestService[] {ts1, ts2}, serviceCache.getServices(TestService.class, null));
+        assertEquals("The ServiceCache should have returned the first service that was registered.", ts1,
+                serviceCache.getService(TestService.class));
+
+        TestService ts3 = new TestService("ts3");
+        Dictionary<String, Object> properties = new Hashtable<>();
+        properties.put(Constants.SERVICE_RANKING, Integer.MAX_VALUE);
+        bundleContext.registerService(TestService.class, ts3, properties);
+        assertArrayEquals(new TestService[] {ts3, ts1, ts2}, serviceCache.getServices(TestService.class, null));
+        assertEquals("The ServiceCache should have now returned the service with the highest ranking.", ts3,
+                serviceCache.getService(TestService.class));
+    }
+
+    private static final class TestService {
+        private final String service;
+
+        public TestService(String service) {
+            this.service = service;
+        }
+    }
+
+
+}


### PR DESCRIPTION
* extended the `ServiceCache` with a `getServices` method that returns a filtered services array
* the `ExecutableUnits` are now backed by the `ServiceCache`