### PR TITLE
SLING-11213 avoid ConcurrentModificationException

### DIFF
--- a/src/main/java/org/apache/sling/scripting/core/impl/jsr223/SlingScriptEngineManager.java
+++ b/src/main/java/org/apache/sling/scripting/core/impl/jsr223/SlingScriptEngineManager.java
@@ -422,15 +422,17 @@ public class SlingScriptEngineManager extends ScriptEngineManager implements Bun
             }
             // and finally factories registered as OSGi services
             if (bundleContext != null) {
-                for (final ServiceReference<ScriptEngineFactory> serviceReference : serviceReferences) {
-                    final ScriptEngineFactory scriptEngineFactory = bundleContext.getService(serviceReference);
-                    if (isIncluded(scriptEngineFactory)) {
-                        final Map<String, Object> factoryProperties = new HashMap<>(serviceReference.getPropertyKeys().length);
-                        for (final String key : serviceReference.getPropertyKeys()) {
-                            factoryProperties.put(key, serviceReference.getProperty(key));
+                synchronized (this.serviceReferences) {
+                    for (final ServiceReference<ScriptEngineFactory> serviceReference : serviceReferences) {
+                        final ScriptEngineFactory scriptEngineFactory = bundleContext.getService(serviceReference);
+                        if (isIncluded(scriptEngineFactory)) {
+                            final Map<String, Object> factoryProperties = new HashMap<>(serviceReference.getPropertyKeys().length);
+                            for (final String key : serviceReference.getPropertyKeys()) {
+                                factoryProperties.put(key, serviceReference.getProperty(key));
+                            }
+                            final SortableScriptEngineFactory sortableScriptEngineFactory = new SortableScriptEngineFactory(scriptEngineFactory, serviceReference.getBundle().getBundleId(), PropertiesUtil.toInteger(serviceReference.getProperty(Constants.SERVICE_RANKING), 0), factoryProperties);
+                            factories.add(sortableScriptEngineFactory);
                         }
-                        final SortableScriptEngineFactory sortableScriptEngineFactory = new SortableScriptEngineFactory(scriptEngineFactory, serviceReference.getBundle().getBundleId(), PropertiesUtil.toInteger(serviceReference.getProperty(Constants.SERVICE_RANKING), 0), factoryProperties);
-                        factories.add(sortableScriptEngineFactory);
                     }
                 }
             }


### PR DESCRIPTION
```updateFactories```  must also synchronize when iterating the ```serviceReferences```. Otherwise calling ```unbindScriptingEngineFactory``` concurrently will cause a ConcurrentModificationException.
