### PR TITLE
SLING-11398 handle ScriptEngineFactory defined in a fragment

### DIFF
--- a/src/test/java/org/apache/sling/scripting/core/impl/jsr223/SlingScriptEngineManagerTest.java
+++ b/src/test/java/org/apache/sling/scripting/core/impl/jsr223/SlingScriptEngineManagerTest.java
@@ -18,6 +18,12 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package org.apache.sling.scripting.core.impl.jsr223;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -48,12 +54,6 @@ import org.osgi.framework.wiring.BundleWiring;
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventConstants;
 import org.osgi.service.event.EventHandler;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class SlingScriptEngineManagerTest {
 
@@ -163,7 +163,7 @@ public class SlingScriptEngineManagerTest {
         when(bundle.adapt(BundleWiring.class)).thenReturn(wiring);
         when(wiring.getClassLoader()).thenReturn(loader);
 
-        when(bundle.getEntry(SlingScriptEngineManager.ENGINE_FACTORY_SERVICE)).thenReturn(url);
+        when(bundle.findEntries(SlingScriptEngineManager.META_INF_SERVICES, SlingScriptEngineManager.FACTORY_NAME, false)).thenReturn(Collections.enumeration(Collections.singleton(url)));
 
         BundleEvent bundleEvent = new BundleEvent(BundleEvent.STARTED, bundle);
         SlingScriptEngineManager slingScriptEngineManager = context.getService(SlingScriptEngineManager.class);

--- a/src/test/java/org/apache/sling/scripting/core/it/SLING_11398IT.java
+++ b/src/test/java/org/apache/sling/scripting/core/it/SLING_11398IT.java
@@ -19,8 +19,10 @@
 package org.apache.sling.scripting.core.it;
 
 import static org.junit.Assert.assertNotNull;
+import static org.ops4j.pax.exam.CoreOptions.composite;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.options;
+import static org.ops4j.pax.exam.CoreOptions.vmOption;
 
 import javax.inject.Inject;
 import javax.script.ScriptEngine;
@@ -31,6 +33,8 @@ import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.options.ModifiableCompositeOption;
+import org.ops4j.pax.exam.options.extra.VMOption;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 
@@ -48,10 +52,24 @@ public class SLING_11398IT extends ScriptingCoreTestSupport {
     public Option[] configuration() {
         return options(
             baseConfiguration(),
-            mavenBundle().groupId("org.codehaus.groovy").artifactId("groovy").version("3.0.9"),
+            optionalRemoteDebug(),
+            mavenBundle().groupId("org.codehaus.groovy").artifactId("groovy").version("3.0.9").startLevel(1),
             // factory is defined in this fragment artifact
             mavenBundle().groupId("org.codehaus.groovy").artifactId("groovy-jsr223").version("3.0.9").noStart()
         );
+    }
+
+    /**
+     * Optionally configure remote debugging on the port supplied by the "debugPort"
+     * system property.
+     */
+    protected ModifiableCompositeOption optionalRemoteDebug() {
+        VMOption option = null;
+        String property = System.getProperty("debugPort");
+        if (property != null) {
+            option = vmOption(String.format("-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=%s", property));
+        }
+        return composite(option);
     }
 
     @Test

--- a/src/test/java/org/apache/sling/scripting/core/it/SLING_11398IT.java
+++ b/src/test/java/org/apache/sling/scripting/core/it/SLING_11398IT.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.scripting.core.it;
+
+import static org.junit.Assert.assertNotNull;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.options;
+
+import javax.inject.Inject;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+/**
+ * Tests for SLING-11398 - verify serviceloader ScriptEngineFactory defined in a fragment bundle
+ */
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class SLING_11398IT extends ScriptingCoreTestSupport {
+
+    @Inject
+    private ScriptEngineManager scriptEngineManager;
+
+    @Configuration
+    public Option[] configuration() {
+        return options(
+            baseConfiguration(),
+            mavenBundle().groupId("org.codehaus.groovy").artifactId("groovy").version("3.0.9"),
+            // factory is defined in this fragment artifact
+            mavenBundle().groupId("org.codehaus.groovy").artifactId("groovy-jsr223").version("3.0.9").noStart()
+        );
+    }
+
+    @Test
+    public void testGroovyScriptEngineAvailable() {
+        ScriptEngine engineByExtension = scriptEngineManager.getEngineByExtension("groovy");
+        assertNotNull(engineByExtension);
+    }
+
+}

--- a/src/test/java/org/apache/sling/scripting/core/it/SLING_11398IT.java
+++ b/src/test/java/org/apache/sling/scripting/core/it/SLING_11398IT.java
@@ -54,7 +54,8 @@ public class SLING_11398IT extends ScriptingCoreTestSupport {
             baseConfiguration(),
             optionalRemoteDebug(),
             mavenBundle().groupId("org.codehaus.groovy").artifactId("groovy").version("3.0.9").startLevel(1),
-            // factory is defined in this fragment artifact
+            // factory is defined in this fragment artifact – other versions of this bundle (e.g. 3.0.1) were 
+            //  released as regular bundle, not as fragment
             mavenBundle().groupId("org.codehaus.groovy").artifactId("groovy-jsr223").version("3.0.9").noStart()
         );
     }


### PR DESCRIPTION
Handle loading of ScriptEngineFactory serviceloader (/META-INF/services/javax.script.ScriptEngineFactory) files that exist in a fragment.

For example, consider the groovy ScriptEngine included in the starter that has these:
    Host Bundle - org.codehaus.groovy:groovy:3.0.9
    Fragment - org.codehaus.groovy:groovy-jsr223:3.0.9


Expected:
The groovy ScriptEngineFactory declared in the groovy-jsr223 fragment should be discovered and made available.