### PR TITLE
Fix for NPE when flushBuffer is called before getWriter

### DIFF
--- a/src/main/java/org/apache/sling/scripting/core/servlet/CaptureResponseWrapper.java
+++ b/src/main/java/org/apache/sling/scripting/core/servlet/CaptureResponseWrapper.java
@@ -62,7 +62,7 @@ public final class CaptureResponseWrapper extends HttpServletResponseWrapper {
         if (isBinaryResponse()) {
             getResponse().getOutputStream().flush();
         } else {
-            writer.flush();
+            getWriter.flush();
         }
     }
 

--- a/src/main/java/org/apache/sling/scripting/core/servlet/CaptureResponseWrapper.java
+++ b/src/main/java/org/apache/sling/scripting/core/servlet/CaptureResponseWrapper.java
@@ -62,7 +62,7 @@ public final class CaptureResponseWrapper extends HttpServletResponseWrapper {
         if (isBinaryResponse()) {
             getResponse().getOutputStream().flush();
         } else {
-            getWriter.flush();
+            getWriter().flush();
         }
     }
 


### PR DESCRIPTION
A NPE is thrown when flushBuffer is called before getWriter.