### PR TITLE
SLING-11904 - Sling Scripting Core build fails on Java 17 due to Mockito error:module java.base does not "opens java.lang" to unnamed module @2613a93a

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.9.5</version>
+            <version>5.3.1</version>
             <scope>test</scope>
         </dependency>
         <!-- jsoup -->

--- a/src/test/java/org/apache/sling/scripting/core/impl/ScriptingResourceResolverProviderImplTest.java
+++ b/src/test/java/org/apache/sling/scripting/core/impl/ScriptingResourceResolverProviderImplTest.java
@@ -28,13 +28,13 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import javax.servlet.ServletRequestEvent;
 
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.internal.util.reflection.Whitebox;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -49,7 +49,7 @@ public class ScriptingResourceResolverProviderImplTest {
     private Set<ResourceResolver> delegates;
 
     @Before
-    public void setUp() throws LoginException {
+    public void setUp() throws LoginException, ReflectiveOperationException {
         delegates = Collections.synchronizedSet(new HashSet<ResourceResolver>());
         ResourceResolverFactory rrf = mock(ResourceResolverFactory.class);
         when(rrf.getServiceResourceResolver(null)).thenAnswer(new Answer<ResourceResolver>() {
@@ -61,7 +61,7 @@ public class ScriptingResourceResolverProviderImplTest {
             }
         });
         scriptingResourceResolverFactory = new ScriptingResourceResolverProviderImpl();
-        Whitebox.setInternalState(scriptingResourceResolverFactory, "rrf", rrf);
+        FieldUtils.getField(ScriptingResourceResolverProviderImpl.class, "rrf", true).set(scriptingResourceResolverFactory, rrf);
     }
 
     @After


### PR DESCRIPTION
- use the latest version of mockito
- replace mockito-internal Whitebox with FieldUtils from commons-lang3