### PR TITLE
SLING-13103 - Wrong ResourceResolver set in script bindings after request dispatch in a Jakarta Context

### DIFF
--- a/src/main/java/org/apache/sling/scripting/core/ScriptHelper.java
+++ b/src/main/java/org/apache/sling/scripting/core/ScriptHelper.java
@@ -38,6 +38,7 @@ import org.apache.sling.api.SlingJakartaHttpServletResponse;
 import org.apache.sling.api.SlingServletException;
 import org.apache.sling.api.request.RequestDispatcherOptions;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.scripting.InvalidServiceFilterSyntaxException;
 import org.apache.sling.api.scripting.SlingScript;
 import org.apache.sling.api.scripting.SlingScriptHelper;
@@ -185,7 +186,17 @@ public class ScriptHelper implements SlingScriptHelper {
     @SuppressWarnings("deprecation")
     public SlingHttpServletRequest getRequest() {
         if (this.request == null && this.jakartaRequest != null) {
-            this.request = JakartaToJavaxRequestWrapper.toJavaxRequest(this.jakartaRequest);
+            SlingHttpServletRequest javaxRequest = JakartaToJavaxRequestWrapper.toJavaxRequest(this.jakartaRequest);
+            this.request = new SlingHttpServletRequestWrapper(javaxRequest) {
+                @Override
+                public ResourceResolver getResourceResolver() {
+                    Resource resource = getResource();
+                    if (resource != null) {
+                        return resource.getResourceResolver();
+                    }
+                    return super.getResourceResolver();
+                }
+            };
         }
         return request;
     }

--- a/src/main/java/org/apache/sling/scripting/core/impl/DefaultSlingScript.java
+++ b/src/main/java/org/apache/sling/scripting/core/impl/DefaultSlingScript.java
@@ -659,10 +659,11 @@ class DefaultSlingScript implements SlingScript, Servlet, ServletConfig {
                     throw fail(RESOURCE, "Not the same as resource of the SlingScriptHelper request");
                 }
 
-                if (resolverObject != null && sling.getJakartaRequest().getResourceResolver() != resolverObject) {
+                if (resolverObject != null
+                        && sling.getJakartaRequest().getResource().getResourceResolver() != resolverObject) {
                     throw fail(
                             RESOLVER,
-                            "Not the same as the resource resolver of the SlingScriptHelper request's resolver");
+                            "Not the same as the resource resolver of the SlingScriptHelper request's resource");
                 }
 
                 if (writerObject != null && sling.getJakartaResponse().getWriter() != writerObject) {
@@ -677,7 +678,7 @@ class DefaultSlingScript implements SlingScript, Servlet, ServletConfig {
             bindings.put(RESPONSE, sling.getResponse());
             bindings.put(READER, sling.getJakartaRequest().getReader());
             bindings.put(RESOURCE, sling.getJakartaRequest().getResource());
-            bindings.put(RESOLVER, sling.getJakartaRequest().getResourceResolver());
+            bindings.put(RESOLVER, sling.getJakartaRequest().getResource().getResourceResolver());
             bindings.put(OUT, sling.getJakartaResponse().getWriter());
         }
 

--- a/src/test/java/org/apache/sling/scripting/core/ScriptHelperTest.java
+++ b/src/test/java/org/apache/sling/scripting/core/ScriptHelperTest.java
@@ -107,10 +107,11 @@ public class ScriptHelperTest {
         assertSame(request, scriptHelper.getJakartaRequest());
 
         assertNotNull(scriptHelper.getRequest());
-        assertTrue(scriptHelper.getRequest() instanceof JakartaToJavaxRequestWrapper);
-        assertSame(
-                scriptHelper.getJakartaRequest(),
-                ((JakartaToJavaxRequestWrapper) scriptHelper.getRequest()).getRequest());
+        assertTrue(scriptHelper.getRequest() instanceof SlingHttpServletRequestWrapper);
+        SlingHttpServletRequest delegate =
+                ((SlingHttpServletRequestWrapper) scriptHelper.getRequest()).getSlingRequest();
+        assertTrue(delegate instanceof JakartaToJavaxRequestWrapper);
+        assertSame(scriptHelper.getJakartaRequest(), ((JakartaToJavaxRequestWrapper) delegate).getRequest());
 
         assertNotNull(scriptHelper.getJakartaResponse());
         assertSame(response, scriptHelper.getJakartaResponse());
@@ -163,10 +164,11 @@ public class ScriptHelperTest {
         assertSame(request, ((OnDemandReaderJakartaRequest) scriptHelper.getJakartaRequest()).getRequest());
 
         assertNotNull(scriptHelper.getRequest());
-        assertTrue(scriptHelper.getRequest() instanceof JakartaToJavaxRequestWrapper);
-        assertSame(
-                scriptHelper.getJakartaRequest(),
-                ((JakartaToJavaxRequestWrapper) scriptHelper.getRequest()).getRequest());
+        assertTrue(scriptHelper.getRequest() instanceof SlingHttpServletRequestWrapper);
+        SlingHttpServletRequest delegate =
+                ((SlingHttpServletRequestWrapper) scriptHelper.getRequest()).getSlingRequest();
+        assertTrue(delegate instanceof JakartaToJavaxRequestWrapper);
+        assertSame(scriptHelper.getJakartaRequest(), ((JakartaToJavaxRequestWrapper) delegate).getRequest());
 
         assertNotNull(scriptHelper.getJakartaResponse());
         assertTrue(scriptHelper.getJakartaResponse() instanceof OnDemandWriterJakartaResponse);
@@ -224,10 +226,11 @@ public class ScriptHelperTest {
         assertSame(request, scriptHelper.getJakartaRequest());
 
         assertNotNull(scriptHelper.getRequest());
-        assertTrue(scriptHelper.getRequest() instanceof JakartaToJavaxRequestWrapper);
-        assertSame(
-                scriptHelper.getJakartaRequest(),
-                ((JakartaToJavaxRequestWrapper) scriptHelper.getRequest()).getRequest());
+        assertTrue(scriptHelper.getRequest() instanceof SlingHttpServletRequestWrapper);
+        SlingHttpServletRequest delegate =
+                ((SlingHttpServletRequestWrapper) scriptHelper.getRequest()).getSlingRequest();
+        assertTrue(delegate instanceof JakartaToJavaxRequestWrapper);
+        assertSame(scriptHelper.getJakartaRequest(), ((JakartaToJavaxRequestWrapper) delegate).getRequest());
 
         assertNotNull(scriptHelper.getJakartaResponse());
         assertSame(response, scriptHelper.getJakartaResponse());
@@ -288,10 +291,11 @@ public class ScriptHelperTest {
         assertSame(request, scriptHelper.getJakartaRequest());
 
         assertNotNull(scriptHelper.getRequest());
-        assertTrue(scriptHelper.getRequest() instanceof JakartaToJavaxRequestWrapper);
-        assertSame(
-                scriptHelper.getJakartaRequest(),
-                ((JakartaToJavaxRequestWrapper) scriptHelper.getRequest()).getRequest());
+        assertTrue(scriptHelper.getRequest() instanceof SlingHttpServletRequestWrapper);
+        SlingHttpServletRequest delegate =
+                ((SlingHttpServletRequestWrapper) scriptHelper.getRequest()).getSlingRequest();
+        assertTrue(delegate instanceof JakartaToJavaxRequestWrapper);
+        assertSame(scriptHelper.getJakartaRequest(), ((JakartaToJavaxRequestWrapper) delegate).getRequest());
 
         assertNotNull(scriptHelper.getJakartaResponse());
         assertSame(response, scriptHelper.getJakartaResponse());
@@ -356,10 +360,11 @@ public class ScriptHelperTest {
         assertSame(request, scriptHelper.getJakartaRequest());
 
         assertNotNull(scriptHelper.getRequest());
-        assertTrue(scriptHelper.getRequest() instanceof JakartaToJavaxRequestWrapper);
-        assertSame(
-                scriptHelper.getJakartaRequest(),
-                ((JakartaToJavaxRequestWrapper) scriptHelper.getRequest()).getRequest());
+        assertTrue(scriptHelper.getRequest() instanceof SlingHttpServletRequestWrapper);
+        SlingHttpServletRequest delegate =
+                ((SlingHttpServletRequestWrapper) scriptHelper.getRequest()).getSlingRequest();
+        assertTrue(delegate instanceof JakartaToJavaxRequestWrapper);
+        assertSame(scriptHelper.getJakartaRequest(), ((JakartaToJavaxRequestWrapper) delegate).getRequest());
 
         assertNotNull(scriptHelper.getJakartaResponse());
         assertSame(response, scriptHelper.getJakartaResponse());
@@ -427,10 +432,11 @@ public class ScriptHelperTest {
         assertSame(request, ((OnDemandReaderJakartaRequest) scriptHelper.getJakartaRequest()).getRequest());
 
         assertNotNull(scriptHelper.getRequest());
-        assertTrue(scriptHelper.getRequest() instanceof JakartaToJavaxRequestWrapper);
-        assertSame(
-                scriptHelper.getJakartaRequest(),
-                ((JakartaToJavaxRequestWrapper) scriptHelper.getRequest()).getRequest());
+        assertTrue(scriptHelper.getRequest() instanceof SlingHttpServletRequestWrapper);
+        SlingHttpServletRequest delegate =
+                ((SlingHttpServletRequestWrapper) scriptHelper.getRequest()).getSlingRequest();
+        assertTrue(delegate instanceof JakartaToJavaxRequestWrapper);
+        assertSame(scriptHelper.getJakartaRequest(), ((JakartaToJavaxRequestWrapper) delegate).getRequest());
 
         assertNotNull(scriptHelper.getJakartaResponse());
         assertTrue(scriptHelper.getJakartaResponse() instanceof OnDemandWriterJakartaResponse);


### PR DESCRIPTION
Use the resource resolver from the resource, not the one from the request.