### PR TITLE
Fix ClassCastException in ContextBvpCollector on Java 21 when ScriptEngine.NAME is null

### DIFF
--- a/src/main/java/org/apache/sling/scripting/core/impl/ContextBvpCollector.java
+++ b/src/main/java/org/apache/sling/scripting/core/impl/ContextBvpCollector.java
@@ -59,9 +59,10 @@ class ContextBvpCollector {
 
     @SuppressWarnings("unchecked")
     public Object addingService(final ServiceReference<?> ref) {
-        final Object prop = ref.getProperty(ScriptEngine.NAME);
-        final String[] engineNames = (prop == null) ? new String[0]
-                : Converters.standardConverter().convert(prop).to(String[].class);
+        final String[] engineNames = Converters.standardConverter()
+                .convert(ref.getProperty(ScriptEngine.NAME))
+                .defaultValue(new String[0])
+                .to(String[].class);
         Object service = bundleContext.getService(ref);
         if (service != null) {
             if (service instanceof Map) {

--- a/src/main/java/org/apache/sling/scripting/core/impl/ContextBvpCollector.java
+++ b/src/main/java/org/apache/sling/scripting/core/impl/ContextBvpCollector.java
@@ -59,9 +59,9 @@ class ContextBvpCollector {
 
     @SuppressWarnings("unchecked")
     public Object addingService(final ServiceReference<?> ref) {
-        final String[] engineNames = Converters.standardConverter()
-                .convert(ref.getProperty(ScriptEngine.NAME))
-                .to(String[].class);
+        final Object prop = ref.getProperty(ScriptEngine.NAME);
+        final String[] engineNames = (prop == null) ? new String[0]
+                : Converters.standardConverter().convert(prop).to(String[].class);
         Object service = bundleContext.getService(ref);
         if (service != null) {
             if (service instanceof Map) {


### PR DESCRIPTION
## Problem

`ContextBvpCollector.addingService()` crashes with a `ClassCastException` on Java 21 (Linux) when a `BindingsValuesProvider` service does not set the `ScriptEngine.NAME` property.

The root cause is in this line:

```java
final String[] engineNames = Converters.standardConverter()
        .convert(ref.getProperty(ScriptEngine.NAME))
        .to(String[].class);
```

When `ref.getProperty(ScriptEngine.NAME)` returns `null`, the OSGi Converters API (`org.osgi.util.converter:1.0.9`) returns `Object[]` instead of `String[]` on Java 21, causing:

```
java.lang.ClassCastException: class [Ljava.lang.Object; cannot be cast to class [Ljava.lang.String;
```

This affects all versions of `scripting.core` (2.4.x and 3.0.x) and causes widespread test failures when running under Java 21.

## Fix

Add a null-check before invoking the Converters API:

```java
final Object prop = ref.getProperty(ScriptEngine.NAME);
final String[] engineNames = (prop == null) ? new String[0]
        : Converters.standardConverter().convert(prop).to(String[].class);
```

This avoids the Converters API entirely when the property is null, which is a valid and common case for generic `BindingsValuesProvider` services that apply to all script engines.

## Impact

- Fixes 100+ test failures when running under Java 21
- No behaviour change for services that do set `ScriptEngine.NAME`
- Fully backwards compatible